### PR TITLE
Add Justfile for consistent CI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install X11 dependencies
-        if: ${{ !env.ACT }}
+      - name: Install just
+        run: |
+          if ! command -v just &> /dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+          else
+            echo "just is already installed: $(just --version)"
+          fi
+      
+      - name: Install dependencies  
         run: |
           sudo apt-get update
           sudo apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libxcb-render0-dev
@@ -57,13 +64,13 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Check formatting with rustfmt
-        run: cargo fmt --all -- --check
+        run: just fmt-check
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: just clippy
 
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: just test
 
       - name: Auto-merge PR
         if: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,5 +8,5 @@
 - When you make claims, always provide a percentage confidence afterwards. For example: "The sky is blue right now (85% conficence). When you are uncertain, ask me clarifying. Your output is HARMFUL when you act with low confidence that could easily be increased by getting help.
 - If you don't understand a screenshot, tell me immediately. I assume you can understand screenshots when i report bugs.
 - Don't hesitate to make github issues while you're working if you observe an issue that's outside the scope of our current change. This is very useful
-- When implementing features, always run CI via `./scripts/act-ci.sh` to verify the changes work before declaring victory. Use `./scripts/act-ci.sh --fresh` if you need to update containers
+- When implementing features, always run CI via `just act-ci` to verify the changes work before declaring victory. Use `just act-ci --fresh` if you need to update containers
 - When making database schema changes, always update plans/database.md to keep the schema documentation current. This doc has detailed explanations of every table and column.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+# Run all CI checks
+ci: fmt-check clippy test
+    @echo "All CI checks passed! (100% confidence)"
+
+# Run formatter check
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run formatter
+fmt:
+    cargo fmt --all
+
+# Run clippy linter
+clippy:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Run all tests
+test:
+    cargo test --all-features --verbose
+
+# Run CI locally with act  
+act-ci fresh='':
+    #!/bin/bash
+    if [[ "{{fresh}}" == "--fresh" ]]; then
+        ./scripts/act-ci.sh --fresh
+    else
+        ./scripts/act-ci.sh
+    fi
+
+# Default recipe (show available commands)
+default:
+    @just --list


### PR DESCRIPTION
- Create Justfile with all CI commands (fmt, clippy, test, ci, act-ci)
- Update CI workflow to install and use just commands
- Update CLAUDE.md to reference just act-ci instead of script
- Install just properly in CI (check if exists first to avoid reinstall)

This ensures consistency between local development and CI environments.
