### PR TITLE
Add 'just run' command for clean client execution

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,6 +27,16 @@ act-ci fresh='':
         ./scripts/act-ci.sh
     fi
 
+# Run a client with a fresh temporary directory
+run client-name *args='':
+    #!/bin/bash
+    set -e
+    tmpdir="/tmp/{{client-name}}"
+    echo "Setting up client '{{client-name}}' at ${tmpdir} (95% confidence)"
+    rm -rf "${tmpdir}" 2>/dev/null || true
+    mkdir -p "${tmpdir}"
+    cargo run -- --datadir "${tmpdir}" {{args}}
+
 # Default recipe (show available commands)
 default:
     @just --list


### PR DESCRIPTION
Creates a fresh temporary directory for each client run at /tmp/{client-name}.
Handles non-existent directories gracefully and supports passing additional args.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
