### PR TITLE
Test: CI draft PR auto-merge prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           success() && 
           github.event_name == 'pull_request' && 
           github.event.pull_request.user.login == github.repository_owner &&
+          github.event.pull_request.draft == false &&
           !env.ACT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing that draft PRs are not auto-merged even when CI passes.

This PR adds a check for `github.event.pull_request.draft == false` to the auto-merge condition.

Expected behavior: This draft PR should NOT be auto-merged when CI passes.