### PR TITLE
feat: implement NIP-49 password-protected key storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Justin Moon"]
 nrc-mls = "0.1.0"
 nrc-mls-sqlite-storage = "0.1.0"
 nrc-mls-storage = "0.1.0"
-nostr-sdk = { version = "0.43", features = ["nip59"] }
+nostr-sdk = { version = "0.43", features = ["nip49", "nip59"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 hex = "0.4"

--- a/src/key_storage.rs
+++ b/src/key_storage.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use nostr_sdk::prelude::*;
+use std::fs;
+use std::path::Path;
+
+/// Manages encrypted key storage using NIP-49
+pub struct KeyStorage {
+    keys_path: std::path::PathBuf,
+}
+
+impl KeyStorage {
+    pub fn new(datadir: &Path) -> Self {
+        Self {
+            keys_path: datadir.join("keys.ncryptsec"),
+        }
+    }
+
+    /// Check if encrypted keys exist
+    pub fn keys_exist(&self) -> bool {
+        self.keys_path.exists()
+    }
+
+    /// Save keys encrypted with password using NIP-49
+    pub fn save_encrypted(&self, keys: &Keys, password: &str) -> Result<()> {
+        // Use the encrypt method to create an EncryptedSecretKey
+        let encrypted = keys.secret_key().encrypt(password)?;
+        // Convert to bech32 string for storage
+        let encrypted_str = encrypted.to_bech32()?;
+        fs::write(&self.keys_path, encrypted_str)?;
+        log::info!("Keys saved to {:?}", self.keys_path);
+        Ok(())
+    }
+
+    /// Load and decrypt keys with password
+    pub fn load_encrypted(&self, password: &str) -> Result<Keys> {
+        let encrypted_str = fs::read_to_string(&self.keys_path)?;
+        // Parse the encrypted key from bech32
+        let encrypted = EncryptedSecretKey::from_bech32(&encrypted_str)?;
+        // Decrypt to get the secret key
+        let secret_key = encrypted
+            .decrypt(password)
+            .map_err(|e| anyhow!("Failed to decrypt keys: {}", e))?;
+        Ok(Keys::new(secret_key))
+    }
+
+    /// Delete stored keys
+    pub fn delete(&self) -> Result<()> {
+        if self.keys_path.exists() {
+            fs::remove_file(&self.keys_path)?;
+            log::info!("Deleted keys at {:?}", self.keys_path);
+        }
+        Ok(())
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,7 +16,7 @@ pub fn draw(f: &mut Frame, nrc: &Nrc) {
 
     match &nrc.state {
         AppState::Onboarding { input, mode } => {
-            draw_onboarding(f, chunks[0], input, mode);
+            draw_onboarding(f, chunks[0], input, mode, nrc.last_error.as_deref());
         }
         AppState::Initializing => {
             draw_initializing(f, chunks[0]);
@@ -27,7 +27,13 @@ pub fn draw(f: &mut Frame, nrc: &Nrc) {
     }
 }
 
-fn draw_onboarding(f: &mut Frame, area: Rect, input: &str, mode: &OnboardingMode) {
+fn draw_onboarding(
+    f: &mut Frame,
+    area: Rect,
+    input: &str,
+    mode: &OnboardingMode,
+    error: Option<&str>,
+) {
     let block = Block::default()
         .title("╔═══ NRC - ONBOARDING ═══╗")
         .borders(Borders::ALL)
@@ -193,6 +199,137 @@ fn draw_onboarding(f: &mut Frame, area: Rect, input: &str, mode: &OnboardingMode
                     Span::raw("  "),
                     Span::styled("[ESC] ", Style::default().fg(Color::Red)),
                     Span::raw("Cancel"),
+                ]),
+            ];
+
+            let help_text = Paragraph::new(help).alignment(Alignment::Center);
+            f.render_widget(help_text, input_area[1]);
+        }
+        OnboardingMode::CreatePassword => {
+            let content = vec![
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "Create a password to encrypt your keys:",
+                    Style::default().fg(Color::Yellow),
+                )]),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "This password will be required each time you start NRC",
+                    Style::default().fg(Color::DarkGray),
+                )]),
+                Line::from(""),
+            ];
+
+            let paragraph = Paragraph::new(content)
+                .style(Style::default())
+                .alignment(Alignment::Center);
+            f.render_widget(paragraph, chunks[1]);
+
+            // Hide password input
+            let masked_input = "*".repeat(input.len());
+            let input_box = Paragraph::new(masked_input)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                )
+                .style(Style::default().fg(Color::White));
+
+            let input_area = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Min(0)])
+                .split(chunks[2]);
+
+            // Center the password input box
+            let centered_input = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(35),
+                    Constraint::Percentage(30),
+                    Constraint::Percentage(35),
+                ])
+                .split(input_area[0]);
+
+            f.render_widget(input_box, centered_input[1]);
+
+            let help = vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("[ENTER] ", Style::default().fg(Color::Green)),
+                    Span::raw("Continue"),
+                    Span::raw("  "),
+                    Span::styled("[ESC] ", Style::default().fg(Color::Red)),
+                    Span::raw("Back"),
+                ]),
+            ];
+
+            let help_text = Paragraph::new(help).alignment(Alignment::Center);
+            f.render_widget(help_text, input_area[1]);
+        }
+        OnboardingMode::EnterPassword => {
+            let mut content = vec![
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "Welcome back!",
+                    Style::default().fg(Color::Green),
+                )]),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "Enter your password to decrypt your keys:",
+                    Style::default().fg(Color::Yellow),
+                )]),
+            ];
+
+            // Show error if present
+            if let Some(err) = error {
+                content.push(Line::from(""));
+                content.push(Line::from(vec![Span::styled(
+                    err,
+                    Style::default().fg(Color::Red),
+                )]));
+            }
+
+            content.push(Line::from(""));
+
+            let paragraph = Paragraph::new(content)
+                .style(Style::default())
+                .alignment(Alignment::Center);
+            f.render_widget(paragraph, chunks[1]);
+
+            // Hide password input
+            let masked_input = "*".repeat(input.len());
+            let input_box = Paragraph::new(masked_input)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                )
+                .style(Style::default().fg(Color::White));
+
+            let input_area = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Min(0)])
+                .split(chunks[2]);
+
+            // Center the password input box
+            let centered_input = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(35),
+                    Constraint::Percentage(30),
+                    Constraint::Percentage(35),
+                ])
+                .split(input_area[0]);
+
+            f.render_widget(input_box, centered_input[1]);
+
+            let help = vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("[ENTER] ", Style::default().fg(Color::Green)),
+                    Span::raw("Unlock"),
                 ]),
             ];
 


### PR DESCRIPTION
## Summary
- Implement encrypted key storage using NIP-49 specification
- Add password creation flow for new users during onboarding
- Add password prompt for returning users to decrypt stored keys
- Store encrypted keys in ncryptsec format

## Implementation Details
- Uses nostr-sdk's built-in NIP-49 support with XChaCha20-Poly1305 encryption
- Implements scrypt key derivation for secure password-based encryption
- Keys stored at `{datadir}/keys.ncryptsec` and persist across sessions
- Password input is masked in the UI for security
- Error handling for incorrect passwords with retry capability

## User Flow
1. **New users**: Enter display name → Create password → Keys encrypted and saved
2. **Importing keys**: Enter nsec → Create password → Keys encrypted and saved  
3. **Returning users**: Automatically prompted for password to decrypt stored keys

## Note on Performance
The encryption/decryption takes a few seconds due to the scrypt parameters used by nostr-sdk's default implementation. This provides strong protection against brute force attacks but could be optimized in the future by using a configurable log_n parameter.

🤖 Generated with [Claude Code](https://claude.ai/code)