### PR TITLE
Add concise README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+# NRC - Nostr Relay Chat
 
+A terminal-based chat client using the Nostr protocol with MLS encryption for secure group messaging.
+
+## Prerequisites
+
+- Rust 1.70+ and Cargo
+- Terminal with TUI support
+
+## Quick Start
+
+```bash
+# Build and run with temporary data directory
+just run tmp
+
+# Or run directly
+cargo run
+```
+
+Press `Ctrl+C` to exit. The app will guide you through key setup and onboarding.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A terminal-based chat client using the Nostr protocol with MLS encryption for se
 ## Prerequisites
 
 - Rust 1.70+ and Cargo
-- Terminal with TUI support
+- Any terminal that can run a TUI
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ A terminal-based chat client using the Nostr protocol with MLS encryption for se
 ## Quick Start
 
 ```bash
-# Build and run with temporary data directory
+# Install from crates.io
+cargo install nrc
+
+# Or build and run with temporary data directory
 just run tmp
 
 # Or run directly


### PR DESCRIPTION
This PR adds a minimal but comprehensive README that provides essential information for users to get started with NRC quickly. The README includes project description, prerequisites, and simple commands to run the application using `just run tmp` or `cargo run`. It also provides basic usage information including how to exit the application and what to expect during onboarding.