### PR TITLE
ops: save encrypted keys in background; pass datadir to orchestrator

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -89,6 +89,7 @@ impl App {
             keys.clone(),
             event_tx.clone(),
             ops_cmd_rx,
+            key_storage.datadir().to_path_buf(),
         );
 
         Ok(Self {
@@ -748,8 +749,12 @@ impl App {
                             }
                         }
                     } else {
-                        // CreatePassword mode - save keys first
-                        self.key_storage.save_encrypted(&self.keys, &input)?;
+                        // CreatePassword mode - save keys in background (non-blocking)
+                        let _ = self
+                            .ops_cmd_tx
+                            .send(crate::ops::OpsCommand::SaveEncryptedKeys {
+                                password: input.clone(),
+                            });
 
                         self.navigate_to(PageType::Initializing).await?;
 

--- a/tests/ops_orchestrator.rs
+++ b/tests/ops_orchestrator.rs
@@ -34,7 +34,14 @@ async fn orchestrator_reemits_storage_request_on_resume() {
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<AppEvent>();
     let (ops_cmd_tx, ops_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
 
-    spawn_orchestrator(store.clone(), client, keys.clone(), event_tx, ops_cmd_rx);
+    spawn_orchestrator(
+        store.clone(),
+        client,
+        keys.clone(),
+        event_tx,
+        ops_cmd_rx,
+        tmp.path().to_path_buf(),
+    );
 
     // Wake the orchestrator and expect an OpNeedsStorageCreateGroup event
     let _ = ops_cmd_tx.send(OpsCommand::Wake);


### PR DESCRIPTION
- Add OpsCommand::SaveEncryptedKeys and handle via spawn_blocking
- Pass datadir to spawn_orchestrator; adapt App and tests
- Non-blocking key save on CreatePassword; UI flash on result
