### PR TITLE
tests: rename critical_flows to integration_tests

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+// renamed from critical_flows.rs
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use nostr_sdk::prelude::*;


### PR DESCRIPTION
Rename the integration test module from critical_flows.rs to integration_tests.rs and verify via just ci. All tests pass.