### PR TITLE
Remove distracting 'encrypted keys saved' flash message during onboarding

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -301,12 +301,7 @@ pub fn spawn_orchestrator(
                             tokio::task::spawn_blocking(move || {
                                 let storage = KeyStorage::new(&datadir_clone);
                                 match storage.save_encrypted(&keys_clone, &password) {
-                                    Ok(_) => {
-                                        let _ = event_tx_clone.send(AppEvent::FlashMessage(
-                                            "Encrypted keys saved".to_string(),
-                                            std::time::Duration::from_secs(3),
-                                        ));
-                                    }
+                                    Ok(_) => {}
                                     Err(e) => {
                                         log::error!("Failed to save encrypted keys: {e}");
                                         let _ = event_tx_clone.send(AppEvent::FlashMessage(


### PR DESCRIPTION
The success flash message was unnecessary and distracting during the onboarding flow. Keep the error message as that provides important feedback.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
